### PR TITLE
Add commands to commission thread

### DIFF
--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -90,6 +90,7 @@ class RPCResponseKeyEnum(Enum):
 
 # The exceptions for CHIP Device Controller CLI
 
+
 class ChipDevCtrlException(exceptions.ChipStackException):
     pass
 

--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -1123,8 +1123,8 @@ def __check_supported_os()-> bool:
 
 def main():
     start_rpc_server()
-    
-    # Never reach here
+
+    # Never Executed: does not return here
     optParser = OptionParser()
     optParser.add_option(
         "-r",

--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -90,7 +90,6 @@ class RPCResponseKeyEnum(Enum):
 
 # The exceptions for CHIP Device Controller CLI
 
-
 class ChipDevCtrlException(exceptions.ChipStackException):
     pass
 

--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -1123,8 +1123,8 @@ def __check_supported_os()-> bool:
 
 def main():
     start_rpc_server()
-
-    # Never Executed: does not return here
+    
+    # Never reach here
     optParser = OptionParser()
     optParser.add_option(
         "-r",
@@ -1153,14 +1153,8 @@ def main():
             dest="bluetoothAdapter",
             default="hci0",
             type="str",
-            help="Controller bluetooth adapter ID, use --no-ble to disable bluetooth functions.",
+            help="Controller bluetooth adapter ID",
             metavar="<bluetooth-adapter>",
-        )
-        optParser.add_option(
-            "--no-ble",
-            action="store_true",
-            dest="disableBluetooth",
-            help="Disable bluetooth, calling BLE related feature with this flag results in undefined behavior.",
         )
     (options, remainingArgs) = optParser.parse_args(sys.argv[1:])
 
@@ -1170,9 +1164,7 @@ def main():
 
     adapterId = None
     if sys.platform.startswith("linux"):
-        if options.disableBluetooth:
-            adapterId = None
-        elif not options.bluetoothAdapter.startswith("hci"):
+        if not options.bluetoothAdapter.startswith("hci"):
             print(
                 "Invalid bluetooth adapter: {}, adapter name looks like hci0, hci1 etc.")
             sys.exit(-1)
@@ -1184,14 +1176,8 @@ def main():
                     "Invalid bluetooth adapter: {}, adapter name looks like hci0, hci1 etc.")
                 sys.exit(-1)
 
-    try:
-        devMgrCmd = DeviceMgrCmd(rendezvousAddr=options.rendezvousAddr,
-                                 controllerNodeId=options.controllerNodeId, bluetoothAdapter=adapterId)
-    except Exception as ex:
-        print(ex)
-        print("Failed to bringup CHIPDeviceController CLI")
-        sys.exit(1)
-
+    devMgrCmd = DeviceMgrCmd(rendezvousAddr=options.rendezvousAddr,
+                             controllerNodeId=options.controllerNodeId, bluetoothAdapter=adapterId)
     print("Chip Device Controller Shell")
     if options.rendezvousAddr:
         print("Rendezvous address set to %s" % options.rendezvousAddr)

--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -880,10 +880,10 @@ def echo_alive(message):
     print(message)
     return message
 
-def resolve(fabric_id: int, node_id: int) -> Dict[str, Any]:
+def resolve(fabric_id: str, node_id: int) -> Dict[str, Any]:
     try:
         __check_supported_os()
-        err = device_manager.devCtrl.ResolveNode(fabric_id, node_id)
+        err = device_manager.devCtrl.ResolveNode(int(fabric_id), node_id)
         if err != 0:
             return __get_response_dict(status=StatusCodeEnum.FAILED, error=f"Failed to resolve node, with error code: {err}")
 
@@ -963,15 +963,23 @@ def __format_zcl_arguments_from_dict(optional_args: dict, command: dict) -> Dict
     return formatted_command_args
     
 
-def zcl_add_network(node_id: int, ssid: str, password: str, endpoint_id: Optional[int] = 1, group_id: Optional[int] = 0, breadcrumb: Optional[int] = 0, timeoutMs: Optional[int] = 1000) -> Dict[str, Any] :
+def zcl_add_network(node_id: int, args: Dict[str,str], endpoint_id: Optional[int] = 1, group_id: Optional[int] = 0, breadcrumb: Optional[int] = 0, timeoutMs: Optional[int] = 1000) -> Dict[str, Any] :
     try:
         __check_supported_os()
-        args = {}
-        args['ssid'] = ssid.encode("utf-8") + b'\x00'
-        args['credentials'] = password.encode("utf-8") + b'\x00'
-        args['breadcrumb'] = breadcrumb
-        args['timeoutMs'] = timeoutMs 
-        err, res = device_manager.devCtrl.ZCLSend("NetworkCommissioning", "AddWiFiNetwork", node_id, endpoint_id, group_id, args, blocking=True)
+        command: str  = ""
+        parameters = {}
+        if args.get("ssid") and args.get("password"):
+            parameters['ssid'] = args.get("ssid").encode("utf-8") + b'\x00'
+            parameters['credentials'] = args.get("password").encode("utf-8") + b'\x00'
+            command = "AddWifiNetwork"
+        elif args.get("operationalDataset"):
+            parameters['operationalDataset'] = bytes.fromhex(args.get("operationalDataset"))
+            command = "AddThreadNetwork"
+        else:
+            raise Exception("(ssid and password) or dataset need to be provided")
+        parameters['breadcrumb'] = breadcrumb
+        parameters['timeoutMs'] = timeoutMs 
+        err, res = device_manager.devCtrl.ZCLSend("NetworkCommissioning", command, node_id, endpoint_id, group_id, parameters, blocking=True)
         if err != 0:
             return __get_response_dict(status=StatusCodeEnum.FAILED)
         elif res != None:
@@ -982,20 +990,40 @@ def zcl_add_network(node_id: int, ssid: str, password: str, endpoint_id: Optiona
     except Exception as e:
         return __get_response_dict(status = StatusCodeEnum.FAILED, error = str(e))
 
-def zcl_enable_network(node_id: int, ssid:str, endpoint_id: Optional[int] = 1, group_id: Optional[int] = 0, breadcrumb: Optional[int] = 0, timeoutMs: Optional[int] = 1000) -> Dict[str, Any]:
+def zcl_enable_network(node_id: int, args: Dict[str,str], endpoint_id: Optional[int] = 1, group_id: Optional[int] = 0, breadcrumb: Optional[int] = 0, timeoutMs: Optional[int] = 1000) -> Dict[str, Any]:
     try:
         __check_supported_os()
-        args = {}
-        args['networkID'] = ssid.encode("utf-8") + b'\x00'
-        args['breadcrumb'] = breadcrumb
-        args['timeoutMs'] = timeoutMs 
-  
-        err, res = device_manager.devCtrl.ZCLSend("NetworkCommissioning", "EnableNetwork", node_id, endpoint_id, group_id, args, blocking=True)
+        parameters = {}
+        if args.get("ssid"):
+            parameters['networkID'] = args.get("ssid").encode("utf-8") + b'\x00'
+        elif args.get("extpanid"):
+            parameters['networkID'] = bytes.fromhex(args.get("extpanid"))
+        else:
+            raise Exception("ssid or extpanid need to be provided")
+        parameters['breadcrumb'] = breadcrumb
+        parameters['timeoutMs'] = timeoutMs
+
+        err, res = device_manager.devCtrl.ZCLSend("NetworkCommissioning", "EnableNetwork", node_id, endpoint_id, group_id, parameters, blocking=True)
         if err != 0:
             return __get_response_dict(status=StatusCodeEnum.FAILED)
         else:
-            return __get_response_dict(status=StatusCodeEnum.SUCCESS, result=str(res))
-        
+            return __get_response_dict(status = StatusCodeEnum.SUCCESS, result = str(res))
+    except Exception as e:
+        return __get_response_dict(status = StatusCodeEnum.FAILED, error = str(e))
+
+def zcl_onoff(node_id: int, command:str, endpoint_id: Optional[int] = 1, group_id: Optional[int] = 0) -> Dict[str, Any] :
+    try:
+        __check_supported_os()
+        if not (command in ("Toggle", "On", "Off")):
+            raise Exception(f"{command} is not supported")
+
+        err, res = device_manager.devCtrl.ZCLSend("OnOff", command, node_id, endpoint_id, group_id, {}, blocking=True)
+        if err != 0:
+            return __get_response_dict(status=StatusCodeEnum.FAILED)
+        elif res != None:
+            return __get_response_dict(status=StatusCodeEnum.SUCCESS, result = str(res))
+        else:
+            return __get_response_dict(status=StatusCodeEnum.SUCCESS)
     except Exception as e:
         return __get_response_dict(status=StatusCodeEnum.FAILED, error=str(e))
 
@@ -1074,15 +1102,6 @@ def ble_close():
     except Exception as e:
         return __get_response_dict(status=StatusCodeEnum.FAILED, error=str(e))
 
-def get_fabric_id():
-    try:
-        fabricID = device_manager.devCtrl.GetFabricId()
-        if fabricID == 0:
-            return __get_response_dict(status = StatusCodeEnum.FAILED, error = "Fabric ID not created or encountered an error")
-        return __get_response_dict(status = StatusCodeEnum.SUCCESS, result = fabricID)
-    except Exception as e:
-         return __get_response_dict(status = StatusCodeEnum.FAILED, error = str(e))
-
 def get_pase_data() -> Dict[Any, Any]:
     """
     This method will return valid data only after the ble_connect, ip_connect method has been called
@@ -1108,6 +1127,7 @@ def start_rpc_server():
         server.register_function(get_pase_data)
         server.register_function(get_fabric_id)
         server.register_function(pin_code_parse)
+        server.register_function(zcl_onoff)
         server.register_multicall_functions()
         server.register_function(ble_close)
         server.register_introspection_functions()

--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -1090,7 +1090,6 @@ def start_rpc_server():
     with SimpleXMLRPCServer(("0.0.0.0", 5000), allow_none=True) as server:
         server.register_function(echo_alive)
         server.register_function(ble_scan)
-        server.register_function(resolve)
         server.register_function(ble_connect)
         server.register_function(ip_connect)
         server.register_function(zcl_command)

--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -1074,6 +1074,15 @@ def ble_close():
     except Exception as e:
         return __get_response_dict(status=StatusCodeEnum.FAILED, error=str(e))
 
+def get_fabric_id():
+    try:
+        fabricID = device_manager.devCtrl.GetFabricId()
+        if fabricID == 0:
+            return __get_response_dict(status = StatusCodeEnum.FAILED, error = "Fabric ID not created or encountered an error")
+        return __get_response_dict(status = StatusCodeEnum.SUCCESS, result = fabricID)
+    except Exception as e:
+         return __get_response_dict(status = StatusCodeEnum.FAILED, error = str(e))
+
 def get_pase_data() -> Dict[Any, Any]:
     """
     This method will return valid data only after the ble_connect, ip_connect method has been called

--- a/src/controller/python/chip/singleton.py
+++ b/src/controller/python/chip/singleton.py
@@ -1,0 +1,6 @@
+class Singleton(type):
+    _instances = {}
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]


### PR DESCRIPTION
I was rebasing the csg/test_event_3.1 onto test_event_3.1 from origin repository

###Problem
XmlRpc does not support commands to commission thread device

###Change overview
Added methods needed to commission thread device using xmlrpc server

add thread network
enable thread network
send OnOff Toggle zcl command
###Testing
Built python chip controller with the implementation of border router in certification tool can process whole commissioning flow for thread devices.